### PR TITLE
- Replace deprecated 'hiera_hash' to 'lookup'.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@ class git (
   String  $package_ensure = $git::params::package_ensure,
   String  $package_name   = $git::params::package_name,
   Hash[String, Hash[String, String]]
-          $users = hiera_hash('git::users', {}),
+          $users = lookup('git::users', Hash, 'hash', {}),
 ) inherits git::params {
   anchor { "${module_name}::begin": }
   -> class { "${module_name}::sources": }

--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,9 @@
         "12.04",
         "14.04",
         "15.10",
-        "16.04"
+        "16.04",
+        "16.10",
+        "17.04"
       ]
     },
     {
@@ -82,7 +84,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
- Update minimum puppet version required is set to 4.7.0.