### PR TITLE
Fix usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,16 +117,16 @@ git::user{'alice':
  user_email => 'alice@xyz.com',
  gitconfig => {
     'color' => {
-       ui => true,
+       'ui' => true,
     },
     'push' => {
-       default => 'simple',
+       'default' => 'simple',
     },
     'pull' => {
-       ff => 'only',
+       'ff' => 'only',
     },
     'fetch' => {
-       prune => true,
+       'prune' => true,
     },
   }
 }


### PR DESCRIPTION
It seems that the keyword "default" is protected in newer versions of puppet ([see here](https://www.puppet.com/docs/puppet/6/lang_data_default.html)).

This is a simple PR to correct the documented usage example, as this caught me out! 